### PR TITLE
Rename prompt to fcy#

### DIFF
--- a/src/Console.cpp
+++ b/src/Console.cpp
@@ -654,7 +654,7 @@ static void Console(CYOptions &options) {
         }
 
         mode_ = Parsing;
-        char *line(readline("cy# "));
+        char *line(readline("fcy# "));
         mode_ = Working;
 
         if (line == NULL) {


### PR DESCRIPTION
I think that using `fcy#` as the prompt would make more sense since we are not working directly with cycript.