### PR TITLE
Update meson build

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -182,7 +182,7 @@ if get_option('enable_engine')
       python3,
       files('generate-runtime.py'),
       '@INPUT@',
-      '../src/cycript0.9',
+      join_paths(meson.current_source_dir(), 'cycript0.9'),
       '@OUTPUT@',
     ],
     install: true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -169,7 +169,6 @@ if get_option('enable_engine')
     input: [
       'Agent/index.js',
       node_modules,
-      'cycript0.9',
     ],
     output: [
       'libcycript.js',
@@ -183,6 +182,7 @@ if get_option('enable_engine')
       python3,
       files('generate-runtime.py'),
       '@INPUT@',
+      'cycript0.9'
       '@OUTPUT@',
     ],
     install: true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -182,7 +182,7 @@ if get_option('enable_engine')
       python3,
       files('generate-runtime.py'),
       '@INPUT@',
-      'cycript0.9'
+      '../src/cycript0.9',
       '@OUTPUT@',
     ],
     install: true,


### PR DESCRIPTION
Following newest Meson trend, therefore this PR. Updates meson.build script to relative path of cycript0.9.

Test case:

```
$ rm -rf build && meson build --buildtype minsize --strip && ninja -C build
$ ./build/src/cycript
fcy#
```

Prior to this PR, following error was showing up: 

```
Compiler for C++ supports arguments -Wno-overloaded-virtual: YES
src/meson.build:168:2: ERROR: File cycript0.9 does not exist.
```